### PR TITLE
Refactor Frontend User Components

### DIFF
--- a/backend/src/models/user.test.ts
+++ b/backend/src/models/user.test.ts
@@ -27,6 +27,7 @@ describe("authenticate", function () {
   test("works", async function () {
     const user = await User.authenticate("u1@email.com", "password1");
     expect(user).toEqual({
+      id: expect.any(Number),
       email: "u1@email.com",
       firstName: "u1F",
       lastName: "u1L",

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -28,7 +28,8 @@ export class User {
   static async authenticate(email: string, password: string) {
     // try to find the user first
     const result = await db.query(
-      `SELECT email,
+      `SELECT id,
+              email,
               password,
               first_name AS "firstName",
               last_name AS "lastName",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -60,12 +60,10 @@ function App() {
         if (token) {
           try {
             const user = jwt_decode(token);
-            console.log(user);
             const decodedUser = JSON.parse(JSON.stringify(user)).id;
 
             // put the token on the Api class so it can use it to call the API.
             BuskApi.token = token;
-            console.log("decodedUser", decodedUser);
             const currentUser = await BuskApi.getCurrentUser(decodedUser);
 
             setCurrentUser(currentUser);
@@ -110,7 +108,6 @@ function App() {
     const token = await BuskApi.signup(signupData);
     localStorage.setItem("token", token);
     setToken(token);
-    console.log(token.id + " was successfully signed up.");
     return navigate("/events", { replace: true });
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -59,14 +59,14 @@ function App() {
       async function getCurrentUser() {
         if (token) {
           try {
-            const username = jwt_decode(token);
-            const decodedUsername = JSON.parse(
-              JSON.stringify(username)
-            ).username;
+            const user = jwt_decode(token);
+            console.log(user);
+            const decodedUser = JSON.parse(JSON.stringify(user)).id;
 
             // put the token on the Api class so it can use it to call the API.
             BuskApi.token = token;
-            const currentUser = await BuskApi.getCurrentUser(decodedUsername);
+            console.log("decodedUser", decodedUser);
+            const currentUser = await BuskApi.getCurrentUser(decodedUser);
 
             setCurrentUser(currentUser);
           } catch (err) {
@@ -110,7 +110,7 @@ function App() {
     const token = await BuskApi.signup(signupData);
     localStorage.setItem("token", token);
     setToken(token);
-    console.log(token.username + " was successfully signed up.");
+    console.log(token.id + " was successfully signed up.");
     return navigate("/events", { replace: true });
   }
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -47,9 +47,8 @@ class BuskApi {
   /** Get the current user. Takes email.
    * Returns user object {userId, email, firstName, lastName, phone}
    */
-  static async getCurrentUser(email: string) {
-    console.log("getCurrentUser", email);
-    let res = await this.request(`users/${email}`);
+  static async getCurrentUser(id: string) {
+    let res = await this.request(`users/${id}`);
     return res;
   }
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -47,7 +47,7 @@ class BuskApi {
   /** Get the current user. Takes email.
    * Returns user object {userId, email, firstName, lastName, phone}
    */
-  static async getCurrentUser(id: string) {
+  static async getCurrentUser(id: number) {
     let res = await this.request(`users/${id}`);
     return res;
   }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -44,22 +44,23 @@ class BuskApi {
 
   /** User API Routes */
 
-  /** Get the current user. Takes username.
-   * Returns user object {userId, username, firstName, lastName, phone, email}
+  /** Get the current user. Takes email.
+   * Returns user object {userId, email, firstName, lastName, phone}
    */
-  static async getCurrentUser(username: string) {
-    let res = await this.request(`users/${username}`);
+  static async getCurrentUser(email: string) {
+    console.log("getCurrentUser", email);
+    let res = await this.request(`users/${email}`);
     return res;
   }
 
-  /** Log in a user. Takes an object {username, password}. Returns token */
+  /** Log in a user. Takes an object {email, password}. Returns token */
   static async login(loginData: LoginFormData) {
     const res = await this.request("auth/login", loginData, "post");
     return res.token;
   }
 
   /** Signup a new user.
-   *  Takes an object { username, password, firstName, lastName, phone, email }.
+   *  Takes an object { email, password, firstName, lastName, phone }.
    *  Returns token */
   static async signup(signupData: SignupFormData) {
     const res = await this.request("auth/signup", signupData, "post");

--- a/frontend/src/auth/LoginForm.tsx
+++ b/frontend/src/auth/LoginForm.tsx
@@ -12,7 +12,7 @@ import ErrorMessage from "../common/ErrorMessage";
 import { LoginFormData } from "../interfaces/LoginFormData";
 
 interface LoginFormParams {
-  login: (username: LoginFormData) => void;
+  login: (email: LoginFormData) => void;
 }
 
 /**Login form.
@@ -35,7 +35,7 @@ interface LoginFormParams {
 
 function LoginForm({ login }: LoginFormParams) {
   const [formData, setFormData] = useState<LoginFormData>({
-    username: "",
+    email: "",
     password: "",
   });
   const [formErrors, setFormErrors] = useState<string[] | []>([]);
@@ -50,7 +50,7 @@ function LoginForm({ login }: LoginFormParams) {
       await login(formData);
     } catch (err) {
       if (Array.isArray(err)) {
-        setFormErrors(["Invalid username or password."]);
+        setFormErrors(["Invalid email or password."]);
       } else {
         setFormErrors([`${err}`]);
       }
@@ -72,14 +72,14 @@ function LoginForm({ login }: LoginFormParams) {
         <Row className="justify-content-center">
           <Col xs={6} className="">
             <Form.Group className="">
-              <FloatingLabel label="Username" className="mb-3">
+              <FloatingLabel label="Email" className="mb-3">
                 <Form.Control
                   className="form-control"
-                  id="username"
-                  name="username"
-                  value={formData.username}
+                  id="email"
+                  name="email"
+                  value={formData.email}
                   onChange={handleChange}
-                  placeholder="Username"
+                  placeholder="Email"
                 />
               </FloatingLabel>
             </Form.Group>

--- a/frontend/src/auth/SignupForm.tsx
+++ b/frontend/src/auth/SignupForm.tsx
@@ -35,12 +35,11 @@ interface SignupFormParams {
 
 function SignupForm({ signup }: SignupFormParams) {
   const [formData, setFormData] = useState<SignupFormData>({
-    username: "",
+    email: "",
     password: "",
     firstName: "",
     lastName: "",
     phone: "",
-    email: "",
   });
   const [formErrors, setFormErrors] = useState<string[]>([]);
 
@@ -76,14 +75,15 @@ function SignupForm({ signup }: SignupFormParams) {
         <Row className="justify-content-center">
           <Col xs={6}>
             <Form.Group className="">
-              <FloatingLabel label="Username" className="mb-2">
+              <FloatingLabel label="Email" className="mb-2">
                 <Form.Control
                   className="form-control"
-                  id="username"
-                  name="username"
-                  value={formData.username}
+                  type="email"
+                  id="email"
+                  name="email"
+                  value={formData.email}
                   onChange={handleChange}
-                  placeholder="Username"
+                  placeholder="Email"
                 />
               </FloatingLabel>
             </Form.Group>
@@ -136,19 +136,6 @@ function SignupForm({ signup }: SignupFormParams) {
                   value={formData.phone}
                   onChange={handleChange}
                   placeholder="Phone"
-                />
-              </FloatingLabel>
-            </Form.Group>
-            <Form.Group className="">
-              <FloatingLabel label="Email" className="mb-2">
-                <Form.Control
-                  className="form-control"
-                  type="email"
-                  id="email"
-                  name="email"
-                  value={formData.email}
-                  onChange={handleChange}
-                  placeholder="Email"
                 />
               </FloatingLabel>
             </Form.Group>

--- a/frontend/src/interfaces/LoginFormData.ts
+++ b/frontend/src/interfaces/LoginFormData.ts
@@ -1,4 +1,4 @@
 export interface LoginFormData {
-  username: string;
+  email: string;
   password: string;
 }

--- a/frontend/src/interfaces/SignupFormData.ts
+++ b/frontend/src/interfaces/SignupFormData.ts
@@ -1,8 +1,7 @@
 export interface SignupFormData {
-  username: string;
+  email: string;
   password: string;
   firstName: string;
   lastName: string;
   phone: string;
-  email: string;
 }

--- a/frontend/src/routes-nav/AllRoutes.tsx
+++ b/frontend/src/routes-nav/AllRoutes.tsx
@@ -31,7 +31,7 @@ function AllRoutes({ login, signup }: AllRoutesParams) {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/users" element={<UserList />} />
-      <Route path="/users/:username" element={<User />} />
+      <Route path="/users/:id" element={<User />} />
       <Route path="/events" element={<EventList />} />
       <Route path="/events/:id" element={<EventDetail />} />
       <Route path="/login" element={<LoginForm login={login} />} />

--- a/frontend/src/users/User.tsx
+++ b/frontend/src/users/User.tsx
@@ -20,10 +20,10 @@ function User() {
   const currentUser = useContext(UserContext);
   const params = useParams();
 
-  return currentUser && currentUser.username === params.username ? (
+  return currentUser && `${currentUser.id}` === params.id ? (
     <Container>
       <div>
-        <h1> You must be user {currentUser.username} </h1>
+        <h1> You must be user {currentUser.id} </h1>
       </div>
       Events created by the user will go here.
     </Container>

--- a/frontend/src/users/UserContext.ts
+++ b/frontend/src/users/UserContext.ts
@@ -3,12 +3,12 @@ import { createContext } from "react";
 /** Context: provides currentUser object and setter for it throughout app. */
 
 export interface UserContextType {
+  id: number;
   buskerId: number;
-  username: string;
+  email: string;
   firstName: string;
   lastName: string;
   phone: string;
-  email: string;
   isAdmin: boolean;
 }
 


### PR DESCRIPTION
Since we shifted away from the user of `username`, needed to adjust our functions, routes, and components to reflect this change
- Changed login and signup forms to exclude `username` fields
- Updated interfaces to no longer expect a `username` property
- Updated context to use a user's `id` instead of a `username`