### PR TITLE
Refactor frontend events

### DIFF
--- a/backend/src/models/event.test.ts
+++ b/backend/src/models/event.test.ts
@@ -142,7 +142,7 @@ describe("update", function () {
       ...updateData,
       id: testEventIds[0],
       buskerId: testBuskerIds[0],
-      buskerName: testBuskerNames[0]
+      buskerName: testBuskerNames[0],
     });
   });
 

--- a/backend/src/models/event.test.ts
+++ b/backend/src/models/event.test.ts
@@ -11,6 +11,7 @@ import {
   commonAfterAll,
   testBuskerIds,
   testEventIds,
+  testBuskerNames,
 } from "./_testCommon";
 
 beforeAll(commonBeforeAll);
@@ -100,6 +101,7 @@ describe("get", function () {
     expect(event).toEqual({
       id: testEventIds[0],
       buskerId: testBuskerIds[0],
+      buskerName: testBuskerNames[0],
       title: "e1",
       type: "E1",
       coordinates: { lat: 0, lng: 0 },
@@ -140,6 +142,7 @@ describe("update", function () {
       ...updateData,
       id: testEventIds[0],
       buskerId: testBuskerIds[0],
+      buskerName: testBuskerNames[0]
     });
   });
 

--- a/backend/src/models/event.ts
+++ b/backend/src/models/event.ts
@@ -40,9 +40,6 @@ export class Event {
 
     const event = result.rows[0];
 
-    // event.buskerName = (await Busker.get(event.buskerId)).rows[0].buskerId;
-    // console.log(event);
-
     if (!event) throw new NotFoundError(`No such event: ${id}`);
     return event;
   }

--- a/backend/src/routes/eventRoutes.test.ts
+++ b/backend/src/routes/eventRoutes.test.ts
@@ -182,7 +182,7 @@ describe("POST /events", function () {
     expect(resp.statusCode).toEqual(401);
   });
 
-  test("jest bad request if missing eventData", async function () {
+  test("bad request if missing eventData", async function () {
     const resp = await request(app)
       .post(`/events/create`)
       .send({

--- a/backend/src/routes/eventRoutes.test.ts
+++ b/backend/src/routes/eventRoutes.test.ts
@@ -48,6 +48,7 @@ describe("GET /events/:id", function () {
       event: {
         id: testEventIds[0],
         buskerId: testBuskerIds[0],
+        buskerName: testBuskerNames[0],
         title: "test event",
         type: "test type",
         coordinates: { lat: 0, lng: 0 },
@@ -228,6 +229,7 @@ describe("PATCH /events/:id", () => {
       event: {
         id: testEventIds[0],
         buskerId: testBuskerIds[0],
+        buskerName: testBuskerNames[0],
         title: "New title",
         type: "test type",
         coordinates: { lat: 0, lng: 0 },
@@ -250,6 +252,7 @@ describe("PATCH /events/:id", () => {
       event: {
         id: testEventIds[0],
         buskerId: testBuskerIds[0],
+        buskerName: testBuskerNames[0],
         title: "New title",
         type: "test type",
         coordinates: { lat: 0, lng: 0 },

--- a/backend/src/routes/eventRoutes.test.ts
+++ b/backend/src/routes/eventRoutes.test.ts
@@ -187,7 +187,7 @@ describe("POST /events", function () {
       .post(`/events/create`)
       .send({
         userId: testUserIds[0],
-        buskerName: testBuskerNames[0]
+        buskerName: testBuskerNames[0],
       })
       .set("authorization", `Bearer ${adminToken}`);
     expect(resp.statusCode).toEqual(400);

--- a/backend/src/routes/eventRoutes.test.ts
+++ b/backend/src/routes/eventRoutes.test.ts
@@ -181,15 +181,12 @@ describe("POST /events", function () {
     expect(resp.statusCode).toEqual(401);
   });
 
-  test("bad request if missing eventData", async function () {
+  test("jest bad request if missing eventData", async function () {
     const resp = await request(app)
       .post(`/events/create`)
       .send({
         userId: testUserIds[0],
-        buskerName: testBuskerNames[0],
-        eventData: {
-          title: "test event title",
-        },
+        buskerName: testBuskerNames[0]
       })
       .set("authorization", `Bearer ${adminToken}`);
     expect(resp.statusCode).toEqual(400);

--- a/backend/src/routes/eventRoutes.ts
+++ b/backend/src/routes/eventRoutes.ts
@@ -58,8 +58,12 @@ router.post(
   ) {
     try {
       const validator = jsonschema.validate(req.body.eventData, eventNewSchema);
-      if (!validator.valid) {
-        const errs = validator.errors.map((e) => e.stack);
+
+      if (!validator.valid || !req.body.eventData) {
+        const errs =
+          validator.errors.length > 0
+            ? validator.errors.map((e) => e.stack)
+            : "eventData is not defined.";
         throw new BadRequestError(...errs);
       }
       const eventDetails = req.body.eventData;

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -6,7 +6,6 @@ import { LoginFormData } from "../interfaces/LoginFormData";
 import { SignupFormData } from "../interfaces/SignupFormData";
 
 interface EventDataInterface {
-  buskerId: number | undefined;
   title: string;
   type: string;
   coordinates: LatLngExpression;

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -5,7 +5,7 @@ import { BACKEND_BASE_URL } from "../config";
 import { LoginFormData } from "../interfaces/LoginFormData";
 import { SignupFormData } from "../interfaces/SignupFormData";
 
-interface EventDetailsInterface {
+interface EventDataInterface {
   buskerId: number | undefined;
   title: string;
   type: string;
@@ -85,16 +85,33 @@ class BuskApi {
   /** Create a new event.
    *  Takes an object eventDetails { title, type, coordinates }.
    *  Returns event. */
-  static async createEvent(eventDetails: EventDetailsInterface) {
-    const res = await this.request("events/create", eventDetails, "post");
+  static async createEvent(
+    userId: number,
+    buskerName: string,
+    eventData: EventDataInterface
+  ) {
+    const res = await this.request(
+      "events/create",
+      { userId, buskerName, eventData },
+      "post"
+    );
     return res.event;
   }
 
   /** Update an event.
    *  Takes eventId and an object eventDetails { title, type, coordinates }.
    *  Returns event */
-  static async updateEvent(eventId: number, updateData: EventDetailsInterface) {
-    const res = await this.request(`events/${eventId}`, updateData, "patch");
+  static async updateEvent(
+    eventId: number,
+    userId: number,
+    buskerName: string,
+    updateData: EventDataInterface
+  ) {
+    const res = await this.request(
+      `events/${eventId}`,
+      { userId, buskerName, updateData },
+      "patch"
+    );
 
     return res.event;
   }
@@ -102,8 +119,16 @@ class BuskApi {
   /** Get an event.
    *  Takes eventId.
    *  Returns event */
-  static async removeEvent(eventId: number) {
-    const res = await this.request(`events/${eventId}`, {}, "delete");
+  static async removeEvent(
+    eventId: number,
+    userId: number,
+    buskerName: string
+  ) {
+    const res = await this.request(
+      `events/${eventId}`,
+      { userId, buskerName },
+      "delete"
+    );
 
     return res;
   }

--- a/frontend/src/events/AddEventForm.test.tsx
+++ b/frontend/src/events/AddEventForm.test.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { AddEventForm }  from "./AddEventForm";
+import { AddEventForm } from "./AddEventForm";
 import { MemoryRouter } from "react-router";
 
 it("matches snapshot", function () {
   const { asFragment } = render(
-      <MemoryRouter>
-        <AddEventForm submitEvent={()=>{}}/>
-      </MemoryRouter>,
+    <MemoryRouter>
+      <AddEventForm submitEvent={() => {}} />
+    </MemoryRouter>
   );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/frontend/src/events/AddEventForm.tsx
+++ b/frontend/src/events/AddEventForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useState, useContext } from "react";
 import {
   Button,
   Container,
@@ -8,10 +8,16 @@ import {
   FloatingLabel,
 } from "react-bootstrap";
 
+import { UserContext } from "../users/UserContext";
+
 import { AddEventFormData } from "../interfaces/AddEventFormData";
 
 interface AddEventFormParams {
-  submitEvent: (formData: AddEventFormData) => void;
+  submitEvent: (
+    userId: number,
+    buskerName: string,
+    formData: AddEventFormData
+  ) => void;
 }
 
 /**Add Event Form.
@@ -30,6 +36,7 @@ interface AddEventFormParams {
  * EventList -> AddEventForm
  */
 export function AddEventForm({ submitEvent }: AddEventFormParams) {
+  const currentUser = useContext(UserContext);
   const [formData, setFormData] = useState<AddEventFormData>({
     title: "",
     type: "concert",
@@ -41,7 +48,11 @@ export function AddEventForm({ submitEvent }: AddEventFormParams) {
    */
   async function handleSubmit(evt: FormEvent<HTMLFormElement>) {
     evt.preventDefault();
-    submitEvent(formData);
+    if (!currentUser) {
+      console.log("Please log in.");
+    } else {
+      submitEvent(currentUser.id, "Saxiogo", formData);
+    }
   }
 
   /** Update form data field */

--- a/frontend/src/events/EventCard.test.tsx
+++ b/frontend/src/events/EventCard.test.tsx
@@ -5,6 +5,7 @@ import { EventCard } from "./EventCard";
 const demoEvent = {
   id: 1,
   buskerId: 1,
+  buskerName: "demoBusker",
   title: "demo title",
   type: "demo type",
   coordinates: { lat: 1, lng: 1 },

--- a/frontend/src/events/EventCard.tsx
+++ b/frontend/src/events/EventCard.tsx
@@ -1,4 +1,4 @@
-import { Card} from "react-bootstrap";
+import { Card } from "react-bootstrap";
 
 import { Event } from "../interfaces/Event";
 

--- a/frontend/src/events/EventDetail.tsx
+++ b/frontend/src/events/EventDetail.tsx
@@ -84,8 +84,7 @@ export function EventDetail() {
     userId: number,
     formData: UpdateEventFormData
   ) {
-    const eventDetails = {
-      buskerId: 1,
+    const eventData = {
       title: formData.title,
       type: formData.type,
       coordinates: newCoordinates
@@ -106,7 +105,7 @@ export function EventDetail() {
         eventId,
         userId,
         "Saxiogo",
-        eventDetails
+        eventData
       );
       setEvent((previousData) => updatedEvent);
       setErrors([]);
@@ -185,7 +184,7 @@ export function EventDetail() {
                 {" "}
                 <Card.Title>{event.title}</Card.Title>
                 <Card.Text>{event.type}</Card.Text>
-                {event.buskerId === currentUser?.buskerId ? (
+                {currentUser && currentUser?.buskerNames.indexOf(event.buskerName) >= 0 ? (
                   <Container>
                     <Button onClick={toggleUpdateEvent}>Update</Button>
                     <Button onClick={handleRemove}>Remove</Button>

--- a/frontend/src/events/EventDetail.tsx
+++ b/frontend/src/events/EventDetail.tsx
@@ -79,7 +79,11 @@ export function EventDetail() {
    *
    * If any error occurs, updates errors state with errors.
    */
-  async function updateEvent(event: Event, formData: UpdateEventFormData) {
+  async function updateEvent(
+    event: Event,
+    userId: number,
+    formData: UpdateEventFormData
+  ) {
     const eventDetails = {
       buskerId: 1,
       title: formData.title,
@@ -98,7 +102,12 @@ export function EventDetail() {
     const eventId = event.id;
 
     try {
-      const updatedEvent = await BuskApi.updateEvent(eventId, eventDetails);
+      const updatedEvent = await BuskApi.updateEvent(
+        eventId,
+        userId,
+        "Saxiogo",
+        eventDetails
+      );
       setEvent((previousData) => updatedEvent);
       setErrors([]);
     } catch (err) {
@@ -119,9 +128,9 @@ export function EventDetail() {
    *
    * If any error occurs, updates errors state with errors.
    */
-  async function removeEvent(eventId: number) {
+  async function removeEvent(eventId: number, userId: number) {
     try {
-      await BuskApi.removeEvent(eventId);
+      await BuskApi.removeEvent(eventId, userId, "Saxiogo");
       return navigate("/events", { replace: true });
     } catch (err) {
       if (Array.isArray(err)) {
@@ -145,8 +154,8 @@ export function EventDetail() {
   }
 
   async function handleRemove() {
-    if (id) {
-      await removeEvent(+id);
+    if (id && currentUser) {
+      await removeEvent(+id, currentUser.id);
     }
   }
 

--- a/frontend/src/events/EventDetail.tsx
+++ b/frontend/src/events/EventDetail.tsx
@@ -181,10 +181,10 @@ export function EventDetail() {
           ) : (
             <Container>
               <Card.Body>
-                {" "}
                 <Card.Title>{event.title}</Card.Title>
                 <Card.Text>{event.type}</Card.Text>
-                {currentUser && currentUser?.buskerNames.indexOf(event.buskerName) >= 0 ? (
+                {currentUser &&
+                currentUser?.buskerNames.indexOf(event.buskerName) >= 0 ? (
                   <Container>
                     <Button onClick={toggleUpdateEvent}>Update</Button>
                     <Button onClick={handleRemove}>Remove</Button>

--- a/frontend/src/events/EventList.test.tsx
+++ b/frontend/src/events/EventList.test.tsx
@@ -3,7 +3,6 @@ import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import EventList from "./EventList";
 
-
 it("renders without crashing", function () {
   render(
     <MemoryRouter>
@@ -15,8 +14,8 @@ it("renders without crashing", function () {
 it("matches snapshot", function () {
   const { asFragment } = render(
     <MemoryRouter>
-        <EventList />
-      </MemoryRouter>
+      <EventList />
+    </MemoryRouter>
   );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/frontend/src/events/EventList.tsx
+++ b/frontend/src/events/EventList.tsx
@@ -136,7 +136,11 @@ function EventList() {
    *
    * If any error occurs, updates errors state with errors.
    */
-  async function submitEvent(formData: AddEventFormData) {
+  async function submitEvent(
+    userId: number,
+    buskerName: string,
+    formData: AddEventFormData
+  ) {
     if (!newCoordinates) {
       setErrors(["Please select a location"]);
     } else {
@@ -150,7 +154,11 @@ function EventList() {
         },
       };
       try {
-        const newEvent = await BuskApi.createEvent(eventDetails);
+        const newEvent = await BuskApi.createEvent(
+          userId,
+          buskerName,
+          eventDetails
+        );
         setEvents((previousData) => [...previousData, newEvent]);
         setErrors([]);
       } catch (err) {

--- a/frontend/src/events/UpdateEventForm.test.tsx
+++ b/frontend/src/events/UpdateEventForm.test.tsx
@@ -1,22 +1,22 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { UpdateEventForm }  from "./UpdateEventForm";
+import { UpdateEventForm } from "./UpdateEventForm";
 import { MemoryRouter } from "react-router";
 
 const demoEvent = {
-    id: 1,
-    buskerId: 1,
-    buskerName: "demoBusker",
-    title: "demo title",
-    type: "demo type",
-    coordinates: {lat: 1,lng: 1}
+  id: 1,
+  buskerId: 1,
+  buskerName: "demoBusker",
+  title: "demo title",
+  type: "demo type",
+  coordinates: { lat: 1, lng: 1 },
 };
 
 it("matches snapshot", function () {
   const { asFragment } = render(
-      <MemoryRouter>
-        <UpdateEventForm event={demoEvent} updateEvent={()=>{}}/>
-      </MemoryRouter>,
+    <MemoryRouter>
+      <UpdateEventForm event={demoEvent} updateEvent={() => {}} />
+    </MemoryRouter>
   );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/frontend/src/events/UpdateEventForm.test.tsx
+++ b/frontend/src/events/UpdateEventForm.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router";
 const demoEvent = {
     id: 1,
     buskerId: 1,
+    buskerName: "demoBusker",
     title: "demo title",
     type: "demo type",
     coordinates: {lat: 1,lng: 1}

--- a/frontend/src/events/UpdateEventForm.tsx
+++ b/frontend/src/events/UpdateEventForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useState } from "react";
+import { ChangeEvent, FormEvent, useState, useContext } from "react";
 import {
   Button,
   Container,
@@ -10,10 +10,15 @@ import {
 
 import { UpdateEventFormData } from "../interfaces/UpdateEventFormData";
 import { Event } from "../interfaces/Event";
+import { UserContext } from "../users/UserContext";
 
 interface UpdateEventFormParams {
   event: Event;
-  updateEvent: (event: Event, formData: UpdateEventFormData) => void;
+  updateEvent: (
+    event: Event,
+    userId: number,
+    formData: UpdateEventFormData
+  ) => void;
 }
 
 /**Update Event form.
@@ -34,6 +39,7 @@ interface UpdateEventFormParams {
  * */
 
 export function UpdateEventForm({ event, updateEvent }: UpdateEventFormParams) {
+  const currentUser = useContext(UserContext);
   const [formData, setFormData] = useState<UpdateEventFormData>({
     title: event.title,
     type: event.type,
@@ -45,7 +51,11 @@ export function UpdateEventForm({ event, updateEvent }: UpdateEventFormParams) {
    */
   async function handleSubmit(evt: FormEvent<HTMLFormElement>) {
     evt.preventDefault();
-    updateEvent(event, formData);
+    if (!currentUser) {
+      console.log("Please log in to update the event.");
+    } else {
+      updateEvent(event, currentUser.id, formData);
+    }
   }
 
   /** Update form data field */

--- a/frontend/src/interfaces/Event.ts
+++ b/frontend/src/interfaces/Event.ts
@@ -3,6 +3,7 @@ import { LatLngExpression } from "leaflet";
 export interface Event {
   id: number,
   buskerId: number;
+  buskerName: string;
   title: string;
   type: string;
   coordinates: LatLngExpression;

--- a/frontend/src/map/Map.test.tsx
+++ b/frontend/src/map/Map.test.tsx
@@ -6,6 +6,7 @@ import { MapContainer } from "react-leaflet";
 const demoEvent = {
   id: 1,
   buskerId: 1,
+  buskerName: "demoBusker",
   title: "demo title",
   type: "demo type",
   coordinates: { lat: 1, lng: 1 },

--- a/frontend/src/map/StaticMarker.test.tsx
+++ b/frontend/src/map/StaticMarker.test.tsx
@@ -6,6 +6,7 @@ import { MapContainer } from "react-leaflet";
 const demoEvent = {
   id: 1,
   buskerId: 1,
+  buskerName: "demoBusker",
   title: "demo title",
   type: "demo type",
   coordinates: { lat: 1, lng: 1 },

--- a/frontend/src/users/UserContext.ts
+++ b/frontend/src/users/UserContext.ts
@@ -4,12 +4,11 @@ import { createContext } from "react";
 
 export interface UserContextType {
   id: number;
-  buskerId: number;
   email: string;
   firstName: string;
   lastName: string;
   phone: string;
-  isAdmin: boolean;
+  buskerNames: string[];
 }
 
 export const UserContext = createContext<UserContextType | undefined>(


### PR DESCRIPTION
Backend:
- Refactored event methods get and update to return buskerName with event object.
- Refactored event model and routes tests to account for changes made to model methods.

Frontend:
- Refactored api functions to account to changes made to the backend in PRs #41 
- Refactored AddEventForm, UpdateEventForm.
- Refactored eventData and CurrentUser interfaces.
- Refactored frontend tests that depended on eventData.

Considerations:
- Adding event is broken for new users, because a new user doesn't have a busker account associated, therefore fails backend auth validation (ensureUserOwnsBuskerAccount). Need to implement frontend busker creation, which will be done in separate PR.